### PR TITLE
Bvault

### DIFF
--- a/interfaces/BalancerV2.sol
+++ b/interfaces/BalancerV2.sol
@@ -36,8 +36,67 @@ interface IBalancerVault {
     enum PoolSpecialization {GENERAL, MINIMAL_SWAP_INFO, TWO_TOKEN}
     enum JoinKind {INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT}
     enum ExitKind {EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT}
+    enum SwapKind {GIVEN_IN, GIVEN_OUT}
 
+    /**
+     * @dev Data for each individual swap executed by `batchSwap`. The asset in and out fields are indexes into the
+     * `assets` array passed to that function, and ETH assets are converted to WETH.
+     *
+     * If `amount` is zero, the multihop mechanism is used to determine the actual amount based on the amount in/out
+     * from the previous swap, depending on the swap kind.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct BatchSwapStep {
+        bytes32 poolId;
+        uint256 assetInIndex;
+        uint256 assetOutIndex;
+        uint256 amount;
+        bytes userData;
+    }
+    /**
+     * @dev All tokens in a swap are either sent from the `sender` account to the Vault, or from the Vault to the
+     * `recipient` account.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * If `fromInternalBalance` is true, the `sender`'s Internal Balance will be preferred, performing an ERC20
+     * transfer for the difference between the requested amount and the User's Internal Balance (if any). The `sender`
+     * must have allowed the Vault to use their tokens via `IERC20.approve()`. This matches the behavior of
+     * `joinPool`.
+     *
+     * If `toInternalBalance` is true, tokens will be deposited to `recipient`'s internal balance instead of
+     * transferred. This matches the behavior of `exitPool`.
+     *
+     * Note that ETH cannot be deposited to or withdrawn from Internal Balance: attempting to do so will trigger a
+     * revert.
+     */
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address payable recipient;
+        bool toInternalBalance;
+    }
 
+    /**
+     * @dev Data for a single swap executed by `swap`. `amount` is either `amountIn` or `amountOut` depending on
+     * the `kind` value.
+     *
+     * `assetIn` and `assetOut` are either token addresses, or the IAsset sentinel value for ETH (the zero address).
+     * Note that Pools never interact with ETH directly: it will be wrapped to or unwrapped from WETH by the Vault.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct SingleSwap {
+        bytes32 poolId;
+        SwapKind kind;
+        IAsset assetIn;
+        IAsset assetOut;
+        uint256 amount;
+        bytes userData;
+    }
 
     // enconding formats https://github.com/balancer-labs/balancer-v2-monorepo/blob/master/pkg/balancer-js/src/pool-weighted/encoder.ts
     struct JoinPoolRequest {
@@ -82,6 +141,63 @@ interface IBalancerVault {
         uint256[] calldata balances,
         uint256 lastChangeBlock
     );
+    /**
+     * @dev Performs a swap with a single Pool.
+     *
+     * If the swap is 'given in' (the number of tokens to send to the Pool is known), it returns the amount of tokens
+     * taken from the Pool, which must be greater than or equal to `limit`.
+     *
+     * If the swap is 'given out' (the number of tokens to take from the Pool is known), it returns the amount of tokens
+     * sent to the Pool, which must be less than or equal to `limit`.
+     *
+     * Internal Balance usage and the recipient are determined by the `funds` struct.
+     *
+     * Emits a `Swap` event.
+     */
+    function swap(
+        SingleSwap memory singleSwap,
+        FundManagement memory funds,
+        uint256 limit,
+        uint256 deadline
+    ) external returns (uint256 amountCalculated);
+
+    /**
+     * @dev Performs a series of swaps with one or multiple Pools. In each individual swap, the caller determines either
+     * the amount of tokens sent to or received from the Pool, depending on the `kind` value.
+     *
+     * Returns an array with the net Vault asset balance deltas. Positive amounts represent tokens (or ETH) sent to the
+     * Vault, and negative amounts represent tokens (or ETH) sent by the Vault. Each delta corresponds to the asset at
+     * the same index in the `assets` array.
+     *
+     * Swaps are executed sequentially, in the order specified by the `swaps` array. Each array element describes a
+     * Pool, the token to be sent to this Pool, the token to receive from it, and an amount that is either `amountIn` or
+     * `amountOut` depending on the swap kind.
+     *
+     * Multihop swaps can be executed by passing an `amount` value of zero for a swap. This will cause the amount in/out
+     * of the previous swap to be used as the amount in for the current one. In a 'given in' swap, 'tokenIn' must equal
+     * the previous swap's `tokenOut`. For a 'given out' swap, `tokenOut` must equal the previous swap's `tokenIn`.
+     *
+     * The `assets` array contains the addresses of all assets involved in the swaps. These are either token addresses,
+     * or the IAsset sentinel value for ETH (the zero address). Each entry in the `swaps` array specifies tokens in and
+     * out by referencing an index in `assets`. Note that Pools never interact with ETH directly: it will be wrapped to
+     * or unwrapped from WETH by the Vault.
+     *
+     * Internal Balance usage, sender, and recipient are determined by the `funds` struct. The `limits` array specifies
+     * the minimum or maximum amount of each token the vault is allowed to transfer.
+     *
+     * `batchSwap` can be used to make a single swap, like `swap` does, but doing so requires more gas than the
+     * equivalent `swap` call.
+     *
+     * Emits `Swap` events.
+     */
+    function batchSwap(
+        SwapKind kind,
+        BatchSwapStep[] memory swaps,
+        IAsset[] memory assets,
+        FundManagement memory funds,
+        int256[] memory limits,
+        uint256 deadline
+    ) external payable returns (int256[] memory);
 }
 
 interface IAsset {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,10 @@ def wethTokenPoolId():
     id = 0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a  # weth-dai
     yield id
 
+@pytest.fixture
+def wethToken2PoolId():
+    id = 0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019  # weth-usdc
+    yield id
 
 @pytest.fixture
 def ldoWethPoolId():
@@ -196,10 +200,17 @@ def ldoWethPoolId():
 def swapStepsBal(balWethPoolId, wethTokenPoolId, bal, weth, token):
     yield ([balWethPoolId, wethTokenPoolId], [bal, weth, token])
 
-
 @pytest.fixture
 def swapStepsLdo(ldoWethPoolId, wethTokenPoolId, ldo, weth, token):
     yield ([ldoWethPoolId, wethTokenPoolId], [ldo, weth, token])
+
+@pytest.fixture
+def swapStepsBal2(balWethPoolId, wethToken2PoolId, bal, weth, token2):
+    yield ([balWethPoolId, wethToken2PoolId], [bal, weth, token2])
+
+@pytest.fixture
+def swapStepsLdo2(ldoWethPoolId, wethToken2PoolId, ldo, weth, token2):
+    yield ([ldoWethPoolId, wethToken2PoolId], [ldo, weth, token2])
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,11 +176,39 @@ def pool():
 
 
 @pytest.fixture
-def strategy(strategist, keeper, vault, Strategy, gov, balancer_vault, pool, bal, ldo):
+def balWethPoolId():
+    yield 0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014
+
+
+@pytest.fixture
+def wethTokenPoolId():
+    id = 0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a  # weth-dai
+    yield id
+
+
+@pytest.fixture
+def ldoWethPoolId():
+    id = 0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087  # weth-dai
+    yield id
+
+
+@pytest.fixture
+def swapStepsBal(balWethPoolId, wethTokenPoolId, bal, weth, token):
+    yield ([balWethPoolId, wethTokenPoolId], [bal, weth, token])
+
+
+@pytest.fixture
+def swapStepsLdo(ldoWethPoolId, wethTokenPoolId, ldo, weth, token):
+    yield ([ldoWethPoolId, wethTokenPoolId], [ldo, weth, token])
+
+
+@pytest.fixture
+def strategy(strategist, keeper, vault, Strategy, gov, balancer_vault, pool, bal, ldo, management, swapStepsBal,
+             swapStepsLdo):
     strategy = strategist.deploy(Strategy, vault, balancer_vault, pool, 5, 5, 1_000_000, 2 * 60 * 60)
     strategy.setKeeper(keeper)
-    strategy.whitelistRewards(bal, {'from': gov})
-    strategy.whitelistRewards(ldo, {'from': gov})
+    strategy.whitelistRewards(bal, swapStepsBal, {'from': gov})
+    strategy.whitelistRewards(ldo, swapStepsLdo, {'from': gov})
     vault.addStrategy(strategy, 10_000, 0, 2 ** 256 - 1, 1_000, {"from": gov})
     yield strategy
 

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -9,7 +9,7 @@ def test_clone(accounts, Strategy, strategy, strategist, rewards, keeper, token2
                pool, chain, gov,
                RELATIVE_APPROX,
                bal, bal_whale, ldo, weth, weth_amout,
-               ldo_whale):
+               ldo_whale, swapStepsBal, swapStepsLdo, management):
     with brownie.reverts("Strategy already initialized"):
         strategy.initialize(vault, strategist, rewards, keeper, balancer_vault, pool, 10, 10, 100_000, 2 * 60 * 60)
 
@@ -21,11 +21,11 @@ def test_clone(accounts, Strategy, strategy, strategist, rewards, keeper, token2
         cloned_strategy.initialize(vault, strategist, rewards, keeper, balancer_vault, pool, 10, 10, 100_000,
                                    2 * 60 * 60, {'from': gov})
     cloned_strategy.setKeeper(keeper, {'from': gov})
-    cloned_strategy.whitelistRewards(bal, {'from': gov})
-    cloned_strategy.whitelistRewards(ldo, {'from': gov})
+    cloned_strategy.whitelistRewards(bal, swapStepsBal, {'from': management})
+    cloned_strategy.whitelistRewards(ldo, swapStepsLdo, {'from': management})
     vault2.addStrategy(cloned_strategy, 10_000, 0, 2 ** 256 - 1, 1_000, {"from": gov})
 
     # test operations with clone strategy
     test_operation.test_profitable_harvest(
         chain, token2, vault2, cloned_strategy, user, strategist, amount2, RELATIVE_APPROX, bal, bal_whale, ldo,
-        ldo_whale)
+        ldo_whale, management)

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -9,7 +9,7 @@ def test_clone(accounts, Strategy, strategy, strategist, rewards, keeper, token2
                pool, chain, gov,
                RELATIVE_APPROX,
                bal, bal_whale, ldo, weth, weth_amout,
-               ldo_whale, swapStepsBal, swapStepsLdo, management):
+               ldo_whale, swapStepsBal2, swapStepsLdo2, management):
     with brownie.reverts("Strategy already initialized"):
         strategy.initialize(vault, strategist, rewards, keeper, balancer_vault, pool, 10, 10, 100_000, 2 * 60 * 60)
 
@@ -21,8 +21,8 @@ def test_clone(accounts, Strategy, strategy, strategist, rewards, keeper, token2
         cloned_strategy.initialize(vault, strategist, rewards, keeper, balancer_vault, pool, 10, 10, 100_000,
                                    2 * 60 * 60, {'from': gov})
     cloned_strategy.setKeeper(keeper, {'from': gov})
-    cloned_strategy.whitelistRewards(bal, swapStepsBal, {'from': management})
-    cloned_strategy.whitelistRewards(ldo, swapStepsLdo, {'from': management})
+    cloned_strategy.whitelistRewards(bal, swapStepsBal2, {'from': management})
+    cloned_strategy.whitelistRewards(ldo, swapStepsLdo2, {'from': management})
     vault2.addStrategy(cloned_strategy, 10_000, 0, 2 ** 256 - 1, 1_000, {"from": gov})
 
     # test operations with clone strategy

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -45,7 +45,7 @@ def test_emergency_exit(
 
 def test_profitable_harvest(
         chain, token, vault, strategy, user, strategist, amount, RELATIVE_APPROX, bal, bal_whale, ldo,
-        ldo_whale
+        ldo_whale, management
 ):
     # Deposit to the vault
     token.approve(vault.address, amount, {"from": user})


### PR DESCRIPTION
Changes to get rid of uniswap v2 for selling rewards.
Now uses BalancerV2 pools

One compromise that was made was to get rid of the `ethToWant` gas estimation in order to cleanly remove uniswap (also was running out of bytecode size so it worked out). Harvests can be done weekly and manually so gas check isn't necessary